### PR TITLE
引用内のリンクがうまくいかないので単なるURLに修正

### DIFF
--- a/conventions.md
+++ b/conventions.md
@@ -82,8 +82,7 @@ from .models import User
 
 > パッケージの相対インポートを使ったら、1秒でパッケージ名を変更できたぜ
 > 
-> --- [David Beazley,
-> @dabeaz](https://twitter.com/dabeaz/status/372059407711887360)
+> --- David Beazley (https://twitter.com/dabeaz/status/372059407711887360)
 
 **注記**
 


### PR DESCRIPTION
Markdownで引用内のリンク記法を使おうとするとうまくいかないので、単なるURLのみに修正してみました。
横幅をおさめるためにtwitterアカウントは消しています。こちらでいかがでしょうか。
